### PR TITLE
update readme dependency version to 1.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For Maven:
 <dependency>
   <groupId>org.casbin</groupId>
   <artifactId>jcasbin</artifactId>
-  <version>1.6.3</version>
+  <version>1.8.3</version>
 </dependency>
 ```
 


### PR DESCRIPTION
updated the version mentioned in the readme to 1.8.3, as the older version doesn't support the latest explicit priority model